### PR TITLE
Add datasource leostream_policy

### DIFF
--- a/examples/data-sources/leostream_policies/data-source.tf
+++ b/examples/data-sources/leostream_policies/data-source.tf
@@ -1,0 +1,7 @@
+# Copyright (c) HashiCorp, Inc.
+
+data "leostream_policies" "policy_list" {}
+
+output "policy_list_output" {
+  value = data.leostream_policies.policy_list
+}

--- a/examples/data-sources/leostream_policies/provider.tf
+++ b/examples/data-sources/leostream_policies/provider.tf
@@ -1,0 +1,17 @@
+# Copyright (c) HashiCorp, Inc.
+
+terraform {
+  required_providers {
+    leostream = {
+      source = "registry.terraform.io/hocmodo/leostream"
+
+    }
+  }
+}
+
+// This block configures the Leostream provider.
+provider "leostream" {
+  host     = "https://192.168.178.79"
+  username = "api"
+  password = "System@123"
+}

--- a/leostream/center_data_source.go
+++ b/leostream/center_data_source.go
@@ -14,8 +14,8 @@ import (
 
 // Ensure the implementation satisfies the expected interfaces.
 var (
-	_ datasource.DataSource              = &centersDataSource{}
-	_ datasource.DataSourceWithConfigure = &centersDataSource{}
+	_ datasource.DataSource              = &centerDataSource{}
+	_ datasource.DataSourceWithConfigure = &centerDataSource{}
 )
 
 // NewCentersDataSource is a helper function to simplify the provider implementation.

--- a/leostream/centers_data_source_test.go
+++ b/leostream/centers_data_source_test.go
@@ -3,30 +3,30 @@
 package leostream
 
 import (
-    "testing"
+	"testing"
 
-    "github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
 func TestAccCentersDataSource(t *testing.T) {
-    resource.Test(t, resource.TestCase{
-        ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-        Steps: []resource.TestStep{
-            // Read testing
-            {
-                Config: providerConfig + `data "leostream_centers" "test" {}`,
-                Check: resource.ComposeAggregateTestCheckFunc(
-                    // Verify number of coffees returned
-                    resource.TestCheckResourceAttr("data.leostream_centers.test", "centers.#", "1"),
-                    // Verify the first center to ensure all attributes are set
-                    resource.TestCheckResourceAttr("data.leostream_centers.test", "centers.0.name", "Test AWS center"),
-                    resource.TestCheckResourceAttr("data.leostream_centers.test", "centers.0.flavor", "Z"),
-                    resource.TestCheckResourceAttr("data.leostream_centers.test", "centers.0.online", "1"),
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Read testing
+			{
+				Config: providerConfig + `data "leostream_centers" "test" {}`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					// Verify number of coffees returned
+					resource.TestCheckResourceAttr("data.leostream_centers.test", "centers.#", "1"),
+					// Verify the first center to ensure all attributes are set
+					resource.TestCheckResourceAttr("data.leostream_centers.test", "centers.0.name", "Test AWS center"),
+					resource.TestCheckResourceAttr("data.leostream_centers.test", "centers.0.flavor", "Z"),
+					resource.TestCheckResourceAttr("data.leostream_centers.test", "centers.0.online", "1"),
 					resource.TestCheckResourceAttr("data.leostream_centers.test", "centers.0.status_label", "Online"),
 					resource.TestCheckResourceAttr("data.leostream_centers.test", "centers.0.center_type", "amazon"),
 					resource.TestCheckResourceAttr("data.leostream_centers.test", "centers.0.type_label", "Amazon Web Services"),
-                ),
-            },
-        },
-    })
+				),
+			},
+		},
+	})
 }

--- a/leostream/policy_data_source.go
+++ b/leostream/policy_data_source.go
@@ -75,8 +75,8 @@ func (d *policiesDataSource) Read(ctx context.Context, req datasource.ReadReques
 	// Map response body to model
 	for _, policy := range policies {
 		policyState := policiesModel{
-			ID:   types.Int64Value(int64(policy.ID)),
-			Name: types.StringValue(policy.Name),
+			ID:    types.Int64Value(int64(policy.ID)),
+			Name:  types.StringValue(policy.Name),
 			Notes: types.StringValue(policy.Notes),
 		}
 
@@ -107,7 +107,7 @@ type policiesDataSourceModel struct {
 
 // policiesModel maps policies schema data.
 type policiesModel struct {
-	ID   	types.Int64  	`tfsdk:"id"`
-	Name 	types.String 	`tfsdk:"name"`
-	Notes 	types.String 	`tfsdk:"notes"`
+	ID    types.Int64  `tfsdk:"id"`
+	Name  types.String `tfsdk:"name"`
+	Notes types.String `tfsdk:"notes"`
 }

--- a/leostream/policy_data_source.go
+++ b/leostream/policy_data_source.go
@@ -1,0 +1,113 @@
+// Copyright (c) HashiCorp, Inc.
+
+package leostream
+
+import (
+	"context"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"gitlab.hocmodo.nl/community/leostream-client-go"
+)
+
+// Ensure the implementation satisfies the expected interfaces.
+var (
+	_ datasource.DataSource              = &policiesDataSource{}
+	_ datasource.DataSourceWithConfigure = &policiesDataSource{}
+)
+
+// NewPoliciesDataSource is a helper function to simplify the provider implementation.
+func NewPoliciesDataSource() datasource.DataSource {
+	return &policiesDataSource{}
+}
+
+// policiesDataSource is the data source implementation.
+type policiesDataSource struct {
+	client *leostream.Client
+}
+
+// Metadata returns the data source type name.
+func (d *policiesDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_policies"
+}
+
+// Schema defines the schema for the data source.
+func (d *policiesDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: `The policies data source allows you to retrieve a list of policies from Leostream.`,
+		Attributes: map[string]schema.Attribute{
+			"policies": schema.ListNestedAttribute{
+				Computed: true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"id": schema.Int64Attribute{
+							Description: "Unique identifier for the policy.",
+							Computed:    true,
+						},
+						"name": schema.StringAttribute{
+							Description: "Display name of the policy.",
+							Computed:    true,
+						},
+						"notes": schema.StringAttribute{
+							Description: "Notes for this policy.",
+							Computed:    true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// Read refreshes the Terraform state with the latest data.
+func (d *policiesDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var state policiesDataSourceModel
+
+	policies, err := d.client.GetPolicies()
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Read Leostream Policies",
+			err.Error(),
+		)
+		return
+	}
+
+	// Map response body to model
+	for _, policy := range policies {
+		policyState := policiesModel{
+			ID:   types.Int64Value(int64(policy.ID)),
+			Name: types.StringValue(policy.Name),
+			Notes: types.StringValue(policy.Notes),
+		}
+
+		state.Policies = append(state.Policies, policyState)
+	}
+
+	// Set state
+	diags := resp.State.Set(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+}
+
+// Configure adds the provider configured client to the data source.
+func (d *policiesDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, _ *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	d.client = req.ProviderData.(*leostream.Client)
+}
+
+// policiesDataSourceModel maps the data source schema data.
+type policiesDataSourceModel struct {
+	Policies []policiesModel `tfsdk:"policies"`
+}
+
+// policiesModel maps policies schema data.
+type policiesModel struct {
+	ID   	types.Int64  	`tfsdk:"id"`
+	Name 	types.String 	`tfsdk:"name"`
+	Notes 	types.String 	`tfsdk:"notes"`
+}

--- a/leostream/pool_resource_basic_test.go
+++ b/leostream/pool_resource_basic_test.go
@@ -3,18 +3,18 @@
 package leostream
 
 import (
-    "testing"
+	"testing"
 
-    "github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
 func TestAccPoolBasicResource(t *testing.T) {
-    resource.Test(t, resource.TestCase{
-        ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-        Steps: []resource.TestStep{
-            // Create and Read testing
-            {
-                Config: providerConfig + `
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create and Read testing
+			{
+				Config: providerConfig + `
 resource "leostream_basic_pool" "test" {
   name         = "Basic desktop pool 1"
   display_name = "Test 1"
@@ -32,75 +32,75 @@ resource "leostream_basic_pool" "test" {
   }
 }
 `,
-                Check: resource.ComposeAggregateTestCheckFunc(
-                    // Verify number of attributes
-                    //resource.TestCheckResourceAttr("leostream_basic_pool.test", "attributes.#", "1"),
-                    // Verify attributes
-                    resource.TestCheckResourceAttr("leostream_basic_pool.test", "name", "Basic desktop pool 1"),
-                    resource.TestCheckResourceAttr("leostream_basic_pool.test", "display_name", "Test 1"),
-                    resource.TestCheckResourceAttr("leostream_basic_pool.test", "notes", ""),
-                    resource.TestCheckResourceAttr("leostream_basic_pool.test", "pool_definition.restrict_by", "A"),
-                    resource.TestCheckResourceAttr("leostream_basic_pool.test", "pool_definition.attributes.0.vm_table_field", "server_id"),
-                    resource.TestCheckResourceAttr("leostream_basic_pool.test", "pool_definition.attributes.0.text_to_match", "1"),
-                    resource.TestCheckResourceAttr("leostream_basic_pool.test", "pool_definition.attributes.0.condition_type", "eq"),
-                    // Verify if item has Computed attributes filled.
-                    resource.TestCheckResourceAttr("leostream_basic_pool.test", "running_desktops_threshold", "0"),
-                    resource.TestCheckResourceAttr("leostream_basic_pool.test", "pool_definition.never_rogue", "0"),
-                    resource.TestCheckResourceAttr("leostream_basic_pool.test", "pool_definition.parent_pool_id", "1"),
-                    resource.TestCheckResourceAttr("leostream_basic_pool.test", "pool_definition.pool_attribute_join", "A"),
-                    resource.TestCheckResourceAttr("leostream_basic_pool.test", "pool_definition.use_vmotion", "0"),
-                    resource.TestCheckResourceAttr("leostream_basic_pool.test", "provision.mark_deletable", "0"),
-                    resource.TestCheckResourceAttr("leostream_basic_pool.test", "provision.provision_limits_enforce", "0"),
-                    resource.TestCheckResourceAttr("leostream_basic_pool.test", "provision.provision_max", "0"),
-                    resource.TestCheckResourceAttr("leostream_basic_pool.test", "provision.provision_on_off", "0"),
-                    resource.TestCheckResourceAttr("leostream_basic_pool.test", "provision.provision_server_id", "0"),
-                    resource.TestCheckResourceAttr("leostream_basic_pool.test", "provision.provision_tenant_id", "0"),
-                    resource.TestCheckResourceAttr("leostream_basic_pool.test", "provision.provision_threshold", "0"),
-                    resource.TestCheckResourceAttr("leostream_basic_pool.test", "provision.provision_url", ""),
-                    resource.TestCheckResourceAttr("leostream_basic_pool.test", "provision.provision_vm_display_name", ""),
-                    resource.TestCheckResourceAttr("leostream_basic_pool.test", "provision.provision_vm_id", "0"),
-                    resource.TestCheckResourceAttr("leostream_basic_pool.test", "provision.provision_vm_name", ""),
-                    resource.TestCheckResourceAttr("leostream_basic_pool.test", "provision.provision_vm_name_next_value", "0"),
-                    // Verify dynamic values have any value set in the state.
-                    resource.TestCheckResourceAttrSet("leostream_basic_pool.test", "id"),
-                ),
-            },
-            // // ImportState testing
-            // {
-            //     ResourceName:      "hashicups_order.test",
-            //     ImportState:       true,
-            //     ImportStateVerify: true,
-            //     // The last_updated attribute does not exist in the HashiCups
-            //     // API, therefore there is no value for it during import.
-            //     ImportStateVerifyIgnore: []string{"last_updated"},
-            // },
-//             // Update and Read testing
-//             {
-//                 Config: providerConfig + `
-// resource "hashicups_order" "test" {
-//   attributes = [
-//     {
-//       coffee = {
-//         id = 2
-//       }
-//       quantity = 2
-//     },
-//   ]
-// }
-// `,
-//                 Check: resource.ComposeAggregateTestCheckFunc(
-//                     // Verify first order item updated
-//                     resource.TestCheckResourceAttr("hashicups_order.test", "attributes.0.quantity", "2"),
-//                     resource.TestCheckResourceAttr("hashicups_order.test", "attributes.0.coffee.id", "2"),
-//                     // Verify first coffee item has Computed attributes updated.
-//                     resource.TestCheckResourceAttr("hashicups_order.test", "attributes.0.coffee.description", ""),
-//                     resource.TestCheckResourceAttr("hashicups_order.test", "attributes.0.coffee.image", "/packer.png"),
-//                     resource.TestCheckResourceAttr("hashicups_order.test", "attributes.0.coffee.name", "Packer Spiced Latte"),
-//                     resource.TestCheckResourceAttr("hashicups_order.test", "attributes.0.coffee.price", "350"),
-//                     resource.TestCheckResourceAttr("hashicups_order.test", "attributes.0.coffee.teaser", "Packed with goodness to spice up your images"),
-//                 ),
-//             },
-//             // Delete testing automatically occurs in TestCase
-         },
-    })
+				Check: resource.ComposeAggregateTestCheckFunc(
+					// Verify number of attributes
+					//resource.TestCheckResourceAttr("leostream_basic_pool.test", "attributes.#", "1"),
+					// Verify attributes
+					resource.TestCheckResourceAttr("leostream_basic_pool.test", "name", "Basic desktop pool 1"),
+					resource.TestCheckResourceAttr("leostream_basic_pool.test", "display_name", "Test 1"),
+					resource.TestCheckResourceAttr("leostream_basic_pool.test", "notes", ""),
+					resource.TestCheckResourceAttr("leostream_basic_pool.test", "pool_definition.restrict_by", "A"),
+					resource.TestCheckResourceAttr("leostream_basic_pool.test", "pool_definition.attributes.0.vm_table_field", "server_id"),
+					resource.TestCheckResourceAttr("leostream_basic_pool.test", "pool_definition.attributes.0.text_to_match", "1"),
+					resource.TestCheckResourceAttr("leostream_basic_pool.test", "pool_definition.attributes.0.condition_type", "eq"),
+					// Verify if item has Computed attributes filled.
+					resource.TestCheckResourceAttr("leostream_basic_pool.test", "running_desktops_threshold", "0"),
+					resource.TestCheckResourceAttr("leostream_basic_pool.test", "pool_definition.never_rogue", "0"),
+					resource.TestCheckResourceAttr("leostream_basic_pool.test", "pool_definition.parent_pool_id", "1"),
+					resource.TestCheckResourceAttr("leostream_basic_pool.test", "pool_definition.pool_attribute_join", "A"),
+					resource.TestCheckResourceAttr("leostream_basic_pool.test", "pool_definition.use_vmotion", "0"),
+					resource.TestCheckResourceAttr("leostream_basic_pool.test", "provision.mark_deletable", "0"),
+					resource.TestCheckResourceAttr("leostream_basic_pool.test", "provision.provision_limits_enforce", "0"),
+					resource.TestCheckResourceAttr("leostream_basic_pool.test", "provision.provision_max", "0"),
+					resource.TestCheckResourceAttr("leostream_basic_pool.test", "provision.provision_on_off", "0"),
+					resource.TestCheckResourceAttr("leostream_basic_pool.test", "provision.provision_server_id", "0"),
+					resource.TestCheckResourceAttr("leostream_basic_pool.test", "provision.provision_tenant_id", "0"),
+					resource.TestCheckResourceAttr("leostream_basic_pool.test", "provision.provision_threshold", "0"),
+					resource.TestCheckResourceAttr("leostream_basic_pool.test", "provision.provision_url", ""),
+					resource.TestCheckResourceAttr("leostream_basic_pool.test", "provision.provision_vm_display_name", ""),
+					resource.TestCheckResourceAttr("leostream_basic_pool.test", "provision.provision_vm_id", "0"),
+					resource.TestCheckResourceAttr("leostream_basic_pool.test", "provision.provision_vm_name", ""),
+					resource.TestCheckResourceAttr("leostream_basic_pool.test", "provision.provision_vm_name_next_value", "0"),
+					// Verify dynamic values have any value set in the state.
+					resource.TestCheckResourceAttrSet("leostream_basic_pool.test", "id"),
+				),
+			},
+			// // ImportState testing
+			// {
+			//     ResourceName:      "hashicups_order.test",
+			//     ImportState:       true,
+			//     ImportStateVerify: true,
+			//     // The last_updated attribute does not exist in the HashiCups
+			//     // API, therefore there is no value for it during import.
+			//     ImportStateVerifyIgnore: []string{"last_updated"},
+			// },
+			//             // Update and Read testing
+			//             {
+			//                 Config: providerConfig + `
+			// resource "hashicups_order" "test" {
+			//   attributes = [
+			//     {
+			//       coffee = {
+			//         id = 2
+			//       }
+			//       quantity = 2
+			//     },
+			//   ]
+			// }
+			// `,
+			//                 Check: resource.ComposeAggregateTestCheckFunc(
+			//                     // Verify first order item updated
+			//                     resource.TestCheckResourceAttr("hashicups_order.test", "attributes.0.quantity", "2"),
+			//                     resource.TestCheckResourceAttr("hashicups_order.test", "attributes.0.coffee.id", "2"),
+			//                     // Verify first coffee item has Computed attributes updated.
+			//                     resource.TestCheckResourceAttr("hashicups_order.test", "attributes.0.coffee.description", ""),
+			//                     resource.TestCheckResourceAttr("hashicups_order.test", "attributes.0.coffee.image", "/packer.png"),
+			//                     resource.TestCheckResourceAttr("hashicups_order.test", "attributes.0.coffee.name", "Packer Spiced Latte"),
+			//                     resource.TestCheckResourceAttr("hashicups_order.test", "attributes.0.coffee.price", "350"),
+			//                     resource.TestCheckResourceAttr("hashicups_order.test", "attributes.0.coffee.teaser", "Packed with goodness to spice up your images"),
+			//                 ),
+			//             },
+			//             // Delete testing automatically occurs in TestCase
+		},
+	})
 }

--- a/leostream/poolassignment_resource.go
+++ b/leostream/poolassignment_resource.go
@@ -236,7 +236,7 @@ func (r *poolAssignmentResource) Create(ctx context.Context, req resource.Create
 	// empty state as it's a create operation
 	var state poolAssignmentResourceModel
 
-	CrStored := r.CreateNested(ctx, &plan, &state, &resp.Diagnostics, "2")
+	CrStored := r.CreateNested(ctx, &plan, &state, &resp.Diagnostics, plan.Policy_id.String())
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)
 		return
@@ -305,7 +305,7 @@ func (r *poolAssignmentResource) Update(ctx context.Context, req resource.Update
 		return
 	}
 
-	_ = r.UpdateNested(ctx, &plan, &state, &resp.Diagnostics, "2")
+	_ = r.UpdateNested(ctx, &plan, &state, &resp.Diagnostics, state.Policy_id.String())
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)
 		return
@@ -331,7 +331,7 @@ func (r *poolAssignmentResource) Delete(ctx context.Context, req resource.Delete
 	}
 
 	// Delete existing center
-	err := r.client.DeletePoolAssignment(state.ID.ValueString(), "2", nil)
+	err := r.client.DeletePoolAssignment(state.ID.ValueString(), state.Policy_id.String(), nil)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error Deleting Leostream poolassignment",

--- a/leostream/provider.go
+++ b/leostream/provider.go
@@ -190,6 +190,7 @@ func (p *leostreamProvider) DataSources(_ context.Context) []func() datasource.D
 		NewCentersDataSource,
 		NewGatewaysDataSource,
 		NewCenterDataSource,
+		NewPoliciesDataSource,
 	}
 }
 


### PR DESCRIPTION
The poolassignment resource needs a policy_id to be of use. With this datasource we can lookup an ID for a name.