### PR TITLE
Add WorkSpaces Core Managed Instance fields to aws_pool

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/hashicorp/terraform-plugin-go v0.23.0
 	github.com/hashicorp/terraform-plugin-log v0.9.0
 	github.com/hashicorp/terraform-plugin-testing v1.10.0
-	gitlab.com/hocmodo/leostream-client-go v0.1.8
+	gitlab.com/hocmodo/leostream-client-go v0.1.9
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -147,8 +147,8 @@ github.com/zclconf/go-cty v1.15.0 h1:tTCRWxsexYUmtt/wVxgDClUe+uQusuI443uL6e+5sXQ
 github.com/zclconf/go-cty v1.15.0/go.mod h1:VvMs5i0vgZdhYawQNq5kePSpLAoz8u1xvZgrPIxfnZE=
 github.com/zclconf/go-cty-debug v0.0.0-20240509010212-0d6042c53940 h1:4r45xpDWB6ZMSMNJFMOjqrGHynW3DIBuR2H9j0ug+Mo=
 github.com/zclconf/go-cty-debug v0.0.0-20240509010212-0d6042c53940/go.mod h1:CmBdvvj3nqzfzJ6nTCIwDTPZ56aVGvDrmztiO5g3qrM=
-gitlab.com/hocmodo/leostream-client-go v0.1.8 h1:oErdaCC12n0kYGWThzKWEtmz/1xB0fR+a+6375K7m5E=
-gitlab.com/hocmodo/leostream-client-go v0.1.8/go.mod h1:YThg7NwuJB23PpD+n3XqU9zizTAmw6EnIZuF/v3cmT0=
+gitlab.com/hocmodo/leostream-client-go v0.1.9 h1:cRYTjc5cABoS88wbZSVe76qVPghbD9mEbmC0H6/qhxA=
+gitlab.com/hocmodo/leostream-client-go v0.1.9/go.mod h1:YThg7NwuJB23PpD+n3XqU9zizTAmw6EnIZuF/v3cmT0=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.45.0 h1:jMBrvKuj23MTlT0bQEOBcAE0mjg8mK9RXFhRH6nyF3Q=

--- a/leostream/pool_common_aws.go
+++ b/leostream/pool_common_aws.go
@@ -123,47 +123,53 @@ func (o awsProvisionModel) defaultObject() map[string]attr.Value {
 
 // centerModel maps center schema data
 type awsCenterModel struct {
-	ID               types.Int64  `tfsdk:"id"`
-	Name             types.String `tfsdk:"name"`
-	Type             types.String `tfsdk:"type"`
-	Provision_method types.String `tfsdk:"provision_method"`
-	Launch_template_version types.String `tfsdk:"launch_template_version"`
-	Aws_size         types.String `tfsdk:"aws_size"`
-	Aws_iam_name     types.String `tfsdk:"aws_iam_name"`
-	Aws_sub_net      types.String `tfsdk:"aws_sub_net"`
-	Aws_sec_group    types.String `tfsdk:"aws_sec_group"`
-	Aws_vpc_id       types.String `tfsdk:"aws_vpc_id"`
+	ID                             types.Int64  `tfsdk:"id"`
+	Name                           types.String `tfsdk:"name"`
+	Type                           types.String `tfsdk:"type"`
+	Provision_method               types.String `tfsdk:"provision_method"`
+	Launch_template_version        types.String `tfsdk:"launch_template_version"`
+	Aws_size                       types.String `tfsdk:"aws_size"`
+	Aws_iam_name                   types.String `tfsdk:"aws_iam_name"`
+	Aws_sub_net                    types.String `tfsdk:"aws_sub_net"`
+	Aws_sec_group                  types.String `tfsdk:"aws_sec_group"`
+	Aws_vpc_id                     types.String `tfsdk:"aws_vpc_id"`
+	Aws_deploy_as_managed_instance types.Int64  `tfsdk:"aws_deploy_as_managed_instance"`
+	Aws_mi_tenancy                 types.String `tfsdk:"aws_mi_tenancy"`
 }
 
 // attrTypes - return attribute types for this model
 func (o awsCenterModel) attrTypes() map[string]attr.Type {
 	return map[string]attr.Type{
-		"id":               types.Int64Type,
-		"name":             types.StringType,
-		"type":             types.StringType,
-		"provision_method": types.StringType,
-		"launch_template_version": types.StringType,
-		"aws_size":         types.StringType,
-		"aws_iam_name":     types.StringType,
-		"aws_sub_net":      types.StringType,
-		"aws_sec_group":    types.StringType,
-		"aws_vpc_id":       types.StringType,
+		"id":                             types.Int64Type,
+		"name":                           types.StringType,
+		"type":                           types.StringType,
+		"provision_method":               types.StringType,
+		"launch_template_version":        types.StringType,
+		"aws_size":                       types.StringType,
+		"aws_iam_name":                   types.StringType,
+		"aws_sub_net":                    types.StringType,
+		"aws_sec_group":                  types.StringType,
+		"aws_vpc_id":                     types.StringType,
+		"aws_deploy_as_managed_instance": types.Int64Type,
+		"aws_mi_tenancy":                 types.StringType,
 	}
 }
 
 // defaultObject - return default object for this model
 func (o awsCenterModel) defaultObject() map[string]attr.Value {
 	return map[string]attr.Value{
-		"id":               types.Int64Value(0),
-		"name":             types.StringValue(""),
-		"type":             types.StringValue(""),
-		"provision_method": types.StringValue("image"),
-		"launch_template_version": types.StringValue(""),
-		"aws_size":         types.StringValue(""),
-		"aws_iam_name":     types.StringValue(""),
-		"aws_sub_net":      types.StringValue(""),
-		"aws_sec_group":    types.StringValue(""),
-		"aws_vpc_id":       types.StringValue(""),
+		"id":                             types.Int64Value(0),
+		"name":                           types.StringValue(""),
+		"type":                           types.StringValue(""),
+		"provision_method":               types.StringValue("image"),
+		"launch_template_version":        types.StringValue(""),
+		"aws_size":                       types.StringValue(""),
+		"aws_iam_name":                   types.StringValue(""),
+		"aws_sub_net":                    types.StringValue(""),
+		"aws_sec_group":                  types.StringValue(""),
+		"aws_vpc_id":                     types.StringValue(""),
+		"aws_deploy_as_managed_instance": types.Int64Value(0),
+		"aws_mi_tenancy":                 types.StringValue(""),
 	}
 }
 
@@ -333,6 +339,8 @@ func (o *awsPoolResourceModel) Read(ctx context.Context, client leostream.Client
 		stateCenter.Aws_sub_net = types.StringValue(poolConfig.Provision.Center.Aws_sub_net)
 		stateCenter.Aws_sec_group = types.StringValue(poolConfig.Provision.Center.Aws_sec_group)
 		stateCenter.Aws_vpc_id = types.StringValue(poolConfig.Provision.Center.Aws_vpc_id)
+		stateCenter.Aws_deploy_as_managed_instance = types.Int64Value(poolConfig.Provision.Center.Aws_deploy_as_managed_instance)
+		stateCenter.Aws_mi_tenancy = types.StringValue(poolConfig.Provision.Center.Aws_mi_tenancy)
 
 		// Add center to provision model
 		stateProvision.Center, _ = types.ObjectValueFrom(ctx, awsCenterModel{}.attrTypes(), &stateCenter)
@@ -518,6 +526,8 @@ func (r *awsPoolResource) CreateNested(ctx context.Context, plan *awsPoolResourc
 	centerConfig.Aws_sub_net = planCenter.Aws_sub_net.ValueString()
 	centerConfig.Aws_sec_group = planCenter.Aws_sec_group.ValueString()
 	centerConfig.Aws_vpc_id = planCenter.Aws_vpc_id.ValueString()
+	centerConfig.Aws_deploy_as_managed_instance = planCenter.Aws_deploy_as_managed_instance.ValueInt64()
+	centerConfig.Aws_mi_tenancy = planCenter.Aws_mi_tenancy.ValueString()
 
 	provisionConfig.Center = &centerConfig
 
@@ -701,6 +711,8 @@ func (r *awsPoolResource) UpdateNested(ctx context.Context, plan *awsPoolResourc
 	centerConfig.Aws_sub_net = planCenter.Aws_sub_net.ValueString()
 	centerConfig.Aws_sec_group = planCenter.Aws_sec_group.ValueString()
 	centerConfig.Aws_vpc_id = planCenter.Aws_vpc_id.ValueString()
+	centerConfig.Aws_deploy_as_managed_instance = planCenter.Aws_deploy_as_managed_instance.ValueInt64()
+	centerConfig.Aws_mi_tenancy = planCenter.Aws_mi_tenancy.ValueString()
 
 	provisionConfig.Center = &centerConfig
 
@@ -762,5 +774,3 @@ func (r *awsPoolResource) UpdateNested(ctx context.Context, plan *awsPoolResourc
 		return PoolsStored
 	}
 }
-
-

--- a/leostream/pool_resource_aws.go
+++ b/leostream/pool_resource_aws.go
@@ -412,6 +412,18 @@ func (r *awsPoolResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 								Computed:    true,
 								Default:     stringdefault.StaticString(""),
 							},
+							"aws_deploy_as_managed_instance": schema.Int64Attribute{
+								Description: "0 or 1: Deploy this instance as a WorkSpaces Core Managed Instance.",
+								Optional:    true,
+								Computed:    true,
+								Default:     int64default.StaticInt64(0),
+							},
+							"aws_mi_tenancy": schema.StringAttribute{
+								Description: `The AWS Managed Instance tenancy type: "" = default, "default" = Shared, "dedicated" = Dedicated.`,
+								Optional:    true,
+								Computed:    true,
+								Default:     stringdefault.StaticString(""),
+							},
 						},
 					},
 				},


### PR DESCRIPTION
Add functionality from #29 


- Add `aws_deploy_as_managed_instance` to `provision.center` — enables deploying instances as WorkSpaces Core Managed Instances (0/1)
- Add `aws_mi_tenancy` to `provision.center` — sets the tenancy type (`""`, `"default"`, or `"dedicated"`)
- Bump `leostream-client-go` to [v0.1.9](https://gitlab.com/hocmodo/leostream-client-go/-/releases/v0.1.9), which adds the two new fields to `PoolAwsCenter`

### Usage

```hcl
resource "leostream_aws_pool" "example" {
  name = "my-pool"

  provision {
    center {
      id                             = 1
      aws_deploy_as_managed_instance = 1
      aws_mi_tenancy                 = "dedicated"
    }
  }
}
```