### PR TITLE
Update leostream-client-go dependency to v0.2.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/hashicorp/terraform-plugin-go v0.23.0
 	github.com/hashicorp/terraform-plugin-log v0.9.0
 	github.com/hashicorp/terraform-plugin-testing v1.10.0
-	gitlab.com/hocmodo/leostream-client-go v0.1.9
+	gitlab.com/hocmodo/leostream-client-go v0.2.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -155,8 +155,8 @@ github.com/zclconf/go-cty v1.15.0 h1:tTCRWxsexYUmtt/wVxgDClUe+uQusuI443uL6e+5sXQ
 github.com/zclconf/go-cty v1.15.0/go.mod h1:VvMs5i0vgZdhYawQNq5kePSpLAoz8u1xvZgrPIxfnZE=
 github.com/zclconf/go-cty-debug v0.0.0-20240509010212-0d6042c53940 h1:4r45xpDWB6ZMSMNJFMOjqrGHynW3DIBuR2H9j0ug+Mo=
 github.com/zclconf/go-cty-debug v0.0.0-20240509010212-0d6042c53940/go.mod h1:CmBdvvj3nqzfzJ6nTCIwDTPZ56aVGvDrmztiO5g3qrM=
-gitlab.com/hocmodo/leostream-client-go v0.1.8 h1:oErdaCC12n0kYGWThzKWEtmz/1xB0fR+a+6375K7m5E=
-gitlab.com/hocmodo/leostream-client-go v0.1.8/go.mod h1:YThg7NwuJB23PpD+n3XqU9zizTAmw6EnIZuF/v3cmT0=
+gitlab.com/hocmodo/leostream-client-go v0.2.0 h1:XgpRr34YknbCGiJXpF8VF+DnA0cTXga2Sf8QdiVMNPM=
+gitlab.com/hocmodo/leostream-client-go v0.2.0/go.mod h1:DDqhd4643NSfg0XJKh1Q4ajgwHdflyGXINeM+vwTxUI=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=
 go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=
 go.opentelemetry.io/otel v1.39.0 h1:8yPrr/S0ND9QEfTfdP9V+SiwT4E0G7Y5MO7p85nis48=
@@ -169,8 +169,6 @@ go.opentelemetry.io/otel/sdk/metric v1.39.0 h1:cXMVVFVgsIf2YL6QkRF4Urbr/aMInf+2W
 go.opentelemetry.io/otel/sdk/metric v1.39.0/go.mod h1:xq9HEVH7qeX69/JnwEfp6fVq5wosJsY1mt4lLfYdVew=
 go.opentelemetry.io/otel/trace v1.39.0 h1:2d2vfpEDmCJ5zVYz7ijaJdOF59xLomrvj7bjt6/qCJI=
 go.opentelemetry.io/otel/trace v1.39.0/go.mod h1:88w4/PnZSazkGzz/w84VHpQafiU4EtqqlVdxWy+rNOA=
-gitlab.com/hocmodo/leostream-client-go v0.1.9 h1:cRYTjc5cABoS88wbZSVe76qVPghbD9mEbmC0H6/qhxA=
-gitlab.com/hocmodo/leostream-client-go v0.1.9/go.mod h1:YThg7NwuJB23PpD+n3XqU9zizTAmw6EnIZuF/v3cmT0=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.46.0 h1:cKRW/pmt1pKAfetfu+RCEvjvZkA9RimPbh7bhFjGVBU=


### PR DESCRIPTION
Update the go client tag so that it is able to identify new arguments for workspace